### PR TITLE
Update for consistent of empty message of DenyList and AllowList

### DIFF
--- a/app/src/pages/custom_rules/NoRulesExist.tsx
+++ b/app/src/pages/custom_rules/NoRulesExist.tsx
@@ -16,7 +16,7 @@ export default function NoRulesExist({
     showInput = false,
     composer,
 }: NoRulesExistProps): JSX.Element {
-    const defaultTitle = type === "denied" ? "There are no denied domains yet" : "There are no allowed domains yet";
+    const defaultTitle = type === "denied" ? "There are no denied domains yet." : "There are no allowed domains yet.";
 
     return (
         // On mobile we want this block higher (no scroll). Remove vertical centering on mobile, keep it on md+.


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git
- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## What is the current behavior?

Currently, when AllowList empty, it show message "There are no allowed domains yet." that have dot at the end of sentence ( use text at app/src/pages/custom_rules/CustomRulesCard.tsx ), but in DenyList empty, the message show "There are no denied domains yet" that is missing dot. You can refer attached screenshot for more detail.
<img width="428" height="155" alt="Screenshot 2026-04-15 at 11 35 54 PM" src="https://github.com/user-attachments/assets/23b5613a-48ce-4a64-93f7-e63113854ad9" />
<img width="393" height="136" alt="Screenshot 2026-04-15 at 11 35 58 PM" src="https://github.com/user-attachments/assets/6a8ce6c9-1cdf-45e4-a78b-5a2c404097b5" />

