### PR TITLE
Test: staging publish pipeline (safe to remove)

### DIFF
--- a/announcements.md
+++ b/announcements.md
@@ -5,6 +5,16 @@ Use *** for in-body horizontal rules; a bare --- delimits records.
 -->
 
 ---
+id: dev-pipeline-test-2026-06-12
+category: news
+severity: info
+title: Staging pipeline test — safe to remove
+published_at: 2026-06-12
+expires_at: 2026-06-13
+---
+End-to-end test of the announcements publish flow. Safe to remove.
+
+---
 id: dev-maint-006
 category: feature
 severity: info


### PR DESCRIPTION
Adds a temporary test record to exercise the staging announcements publish flow (PR → CI validation).

- `id: dev-pipeline-test-2026-06-12`, category `news`, severity `info`
- Auto-expires `2026-06-13`
- Safe to remove; **not** for production.

Purpose: confirm the validation workflow runs and passes on a well-formed record.