### PR TITLE
Announce: Blocklists, services, and DNSSEC updates

### DIFF
--- a/announcements.md
+++ b/announcements.md
@@ -6,6 +6,20 @@ See README.md on this branch for the full format and publishing guide.
 -->
 
 ---
+id: 2026-06-blocklists-services-dnssec
+category: feature
+severity: info
+title: Blocklists, services, and DNSSEC updates
+published_at: 2026-06-18
+---
+New additions:
+
+- [Security tab](https://github.com/ivpn/moddns/pull/162) in Blocklists: two malware and phishing lists and a Newly Registered Domain setting.
+- Four general blocklists, including 1Hosts, someonewhocares, and Peter Lowe.
+- Seven Services options, including Twitter/X, TikTok, and Reddit.
+- Fixed earlier DNSSEC validation issues.
+
+---
 id: 2026-06-news-feed-and-faster-web-app
 category: feature
 severity: info


### PR DESCRIPTION
Adds the next announcement to the production feed.

- "Blocklists, services, and DNSSEC updates" (feature, 2026-06-18): the new Blocklists security tab and general blocklists (#162), seven new Services options, and the DNSSEC validation fix.
