### PR TITLE
Announce: New PoP locations, IPv6, profile export/import, custom rules improvements

### DIFF
--- a/announcements.md
+++ b/announcements.md
@@ -6,6 +6,20 @@ See README.md on this branch for the full format and publishing guide.
 -->
 
 ---
+id: 2026-07-locations-ipv6-export-import
+category: feature
+severity: info
+title: New PoP locations, IPv6, profile export/import, custom rules improvements
+published_at: 2026-07-09
+---
+New in modDNS:
+
+- Added two new PoP locations, New York (nys1.dns.moddns.net) and Los Angeles (lax1.dns.moddns.net), to improve latency for users in the US.
+- modDNS now supports IPv6. See the [setup guides](https://moddns.net/setup) for details.
+- Export your profile configuration from [Account preferences](https://moddns.net/account-preferences) and re-import it later.
+- Custom rules can now be grouped, with notes and reordering.
+
+---
 id: 2026-06-blocklists-services-dnssec
 category: feature
 severity: info


### PR DESCRIPTION
Adds the modDNS v0.1.14 announcement to the production feed.

- Covers: two new PoP locations (New York, Los Angeles), IPv6 support, profile export/import, and custom rule grouping.
- Release v0.1.14 (PRs #143 export/import, #173/#177 custom rules, #174 IPv6, #175 locations).
- `published_at: 2026-07-09` — scheduled; stays hidden until then.

Validated locally with the pre-flight parser; CI runs the real API parser.
