### PR TITLE
Announce: CNAME uncloaking, query logs filters

### DIFF
--- a/announcements.md
+++ b/announcements.md
@@ -6,6 +6,20 @@ See README.md on this branch for the full format and publishing guide.
 -->
 
 ---
+id: 2026-08-cname-uncloaking-logs-filters
+category: feature
+severity: info
+title: CNAME uncloaking, query logs filters
+published_at: 2026-08-31
+link: https://github.com/ivpn/moddns/releases/tag/v0.3.0
+---
+Updates in modDNS:
+
+- [CNAME uncloaking](https://github.com/ivpn/moddns/pull/208): every CNAME target in a response is now checked against your blocklists and custom rules, not just the domain you queried. This catches trackers that hide behind a first-party subdomain. It is on by default.
+- [Query logs improvements](https://github.com/ivpn/moddns/pull/243): filter by device, refresh on demand or set an auto-refresh interval, and see when new queries arrive. The filter bar now stays in view while you scroll.
+- New profiles now default to one hour of query log retention instead of one day. Query logs remain off by default. Existing profiles keep their current setting, which you can change in [Settings](https://moddns.net/settings).
+
+---
 id: 2026-07-query-logs-dnscrypt-stamps-rebinding
 category: feature
 severity: info


### PR DESCRIPTION
Announcement for the modDNS 0.3.0 release, deployed to production on 2026-08-31.

Three items, all shipped in v0.3.0:

- CNAME uncloaking #208 — every CNAME target in a response is checked against the profile's blocklists and custom rules, not only the queried name. On by default.
- Query logs UX improvements #243 — server-seeded device filter, one-shot and interval refresh, new-queries indicator, sticky filter bar.
- Default query-log retention for new profiles changed from one day to one hour (part of Logging improvements #221). Logging stays off by default and existing profiles are unaffected, which the record states explicitly.

Fields: category `feature`, severity `info` (brand-colour dot, no escalation), published_at 2026-08-31, no expiry, not pinned. Primary `link` points at the v0.3.0 release notes.

Validated locally with the pre-flight parser before commit.
