### PR TITLE
Release 0.3.1

### DIFF
--- a/api/db/mongodb/account.go
+++ b/api/db/mongodb/account.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ivpn/dns/api/db/errors"
+	"github.com/ivpn/dns/api/internal/validator"
 	"github.com/ivpn/dns/api/model"
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/bson"
@@ -32,7 +33,7 @@ func NewAccountRepository(client *mongo.Client, dbName, collectionName string) A
 
 // Create adds a new account to the accounts collection
 func (r *AccountRepository) CreateAccount(ctx context.Context, email, passwordPlain, accountId, profileId string) (*model.Account, error) {
-	acc, err := model.NewAccount(email, passwordPlain, accountId, profileId)
+	acc, err := model.NewAccount(validator.NormalizeEmail(email), passwordPlain, accountId, profileId)
 	if err != nil {
 		return nil, err
 	}
@@ -87,10 +88,12 @@ func (r *AccountRepository) GetAccountById(ctx context.Context, accountId string
 
 }
 
-// GetAccountByEmail gets account data based on given email address
+// GetAccountByEmail gets account data based on given email address.
+// The lookup key is normalized to the canonical stored form, so any
+// casing/whitespace variant of the address matches.
 func (r *AccountRepository) GetAccountByEmail(ctx context.Context, email string) (*model.Account, error) {
-	// TODO: create email index
-	filterBson := bson.D{primitive.E{Key: "email", Value: email}}
+	// Unique index "email" created by migration 013.
+	filterBson := bson.D{primitive.E{Key: "email", Value: validator.NormalizeEmail(email)}}
 
 	var account model.Account
 	if err := r.accountsCollection.FindOne(ctx, filterBson).Decode(&account); err != nil {

--- a/api/db/mongodb/account_test.go
+++ b/api/db/mongodb/account_test.go
@@ -244,6 +244,35 @@ func (s *AccountRepositorySuite) TestGetByEmailAndToken() {
 	s.Equal(acc.ID, gotByToken.ID, "token lookup mismatch")
 }
 
+// TestEmailCaseInsensitiveRoundTrip validates that emails are stored in
+// canonical lowercase form and that lookups tolerate any casing/whitespace.
+// specRef: api-endpoint-behaviour.md A1, B6, C1
+func (s *AccountRepositorySuite) TestEmailCaseInsensitiveRoundTrip() {
+	if s.client == nil {
+		s.T().Skip("client unavailable")
+	}
+	ctx := context.Background()
+
+	accountID := primitive.NewObjectID().Hex()
+	acc, err := s.repo.CreateAccount(ctx, " Mixed.Case@Example.COM ", "secret", accountID, "profile-case")
+	s.Require().NoError(err, "CreateAccount")
+	s.Equal("mixed.case@example.com", acc.Email, "stored email must be canonical lowercase")
+
+	fetched, err := s.repo.GetAccountById(ctx, accountID)
+	s.Require().NoError(err, "GetAccountById")
+	s.Equal("mixed.case@example.com", fetched.Email, "persisted email must be canonical lowercase")
+
+	for _, variant := range []string{
+		"mixed.case@example.com",
+		"MIXED.CASE@EXAMPLE.COM",
+		" Mixed.Case@Example.COM ",
+	} {
+		got, err := s.repo.GetAccountByEmail(ctx, variant)
+		s.Require().NoError(err, "GetAccountByEmail(%q)", variant)
+		s.Equal(acc.ID, got.ID, "lookup by %q must find the account", variant)
+	}
+}
+
 // Entry point.
 func TestAccountRepositorySuite(t *testing.T) {
 	suite.Run(t, new(AccountRepositorySuite))

--- a/api/db/mongodb/migrations/025_accounts_email_lowercase.down.json
+++ b/api/db/mongodb/migrations/025_accounts_email_lowercase.down.json
@@ -1,0 +1,13 @@
+[
+  {
+    "update": "accounts",
+    "updates": [
+      {
+        "q": { "__migration_025_never_matches__": true },
+        "u": { "$set": { "__noop__": true } },
+        "multi": false
+      }
+    ],
+    "writeConcern": { "w": "majority" }
+  }
+]

--- a/api/db/mongodb/migrations/025_accounts_email_lowercase.up.json
+++ b/api/db/mongodb/migrations/025_accounts_email_lowercase.up.json
@@ -1,0 +1,15 @@
+[
+  {
+    "update": "accounts",
+    "updates": [
+      {
+        "q": { "$expr": { "$ne": ["$email", { "$toLower": "$email" }] } },
+        "u": [
+          { "$set": { "email": { "$toLower": "$email" } } }
+        ],
+        "multi": true
+      }
+    ],
+    "writeConcern": { "w": "majority" }
+  }
+]

--- a/api/db/mongodb/migrations/README.md
+++ b/api/db/mongodb/migrations/README.md
@@ -5,6 +5,15 @@ golang-migrate for mongoDB uses `db.runCommand( { <command> } )` syntax: https:/
 https://pkg.go.dev/github.com/golang-migrate/migrate/v4/database/mongodb#section-readme
 
 
+### Migration 025 (accounts email lowercase)
+
+Backfills `accounts.email` to lowercase (`$toLower`; idempotent via `$expr` filter).
+The unique `email` index (migration 013) makes this fail mid-update — dirty migration,
+API startup blocked — if two accounts differ only in casing. Before deploying, audit
+the target environment: case-collision groups must be zero, and emails must be ASCII
+without surrounding whitespace (`$toLower` is ASCII-only; the migration does not trim).
+Audit queries are in the PR that introduced the migration.
+
 ### Query logs collections
 
 Note: Query logs time-series collections are created by the proxy service. Their only index is the `{profile_id, timestamp}` meta+time index MongoDB creates automatically on time-series creation (≥6.3) — no code creates query-log indexes explicitly (verified against prod, moddns-shadow#688).

--- a/api/internal/validator/validator.go
+++ b/api/internal/validator/validator.go
@@ -299,3 +299,14 @@ func IsSafeName(s string) bool {
 func NormalizeName(s string) string {
 	return norm.NFC.String(strings.TrimSpace(s))
 }
+
+// NormalizeEmail returns the canonical storage form of an email address:
+// surrounding whitespace trimmed, whole address lowercased. RFC 5321 §2.4
+// allows case-sensitive local parts, but no mainstream provider honors that;
+// addresses are treated case-insensitively throughout. Apply at the storage
+// boundary and on every email lookup key. Deliberately no NFC: migration 025
+// backfills stored emails with Mongo $toLower, and both must produce
+// identical bytes.
+func NormalizeEmail(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}

--- a/api/internal/validator/validator_test.go
+++ b/api/internal/validator/validator_test.go
@@ -39,7 +39,7 @@ func TestValidatePassword(t *testing.T) {
 		// characters must not let a short password pass, nor wrongly reject a
 		// password whose byte length exceeds 64 but whose rune length does not.
 		{"multibyte short rejected (7 chars, 19 bytes)", "Aa1!😀😀😀", false},
-		{"multibyte 12 chars accepted (>12 bytes)", "Aa1!" + strings.Repeat("😀", 8), true}, // 12 chars, 36 bytes
+		{"multibyte 12 chars accepted (>12 bytes)", "Aa1!" + strings.Repeat("😀", 8), true},  // 12 chars, 36 bytes
 		{"multibyte 64 chars accepted (>64 bytes)", "Aa1!" + strings.Repeat("é", 60), true}, // 64 chars, 124 bytes
 		{"multibyte 65 chars rejected", "Aa1!" + strings.Repeat("é", 61), false},            // 65 chars
 		{"empty", "", false},
@@ -236,6 +236,32 @@ func Test_NormalizeName(t *testing.T) {
 			got := NormalizeName(tt.in)
 			if got != tt.want {
 				t.Errorf("NormalizeName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_NormalizeEmail(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lowercases", "User@Example.COM", "user@example.com"},
+		{"trims surrounding whitespace", "  user@example.com  ", "user@example.com"},
+		{"trims and lowercases", " User@Example.COM ", "user@example.com"},
+		{"already canonical unchanged", "user@example.com", "user@example.com"},
+		{"empty stays empty", "", ""},
+		{"whitespace-only collapses to empty", "   ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeEmail(tt.in)
+			if got != tt.want {
+				t.Errorf("NormalizeEmail(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if again := NormalizeEmail(got); again != got {
+				t.Errorf("NormalizeEmail not idempotent: %q -> %q", got, again)
 			}
 		})
 	}

--- a/api/service/account/account.go
+++ b/api/service/account/account.go
@@ -509,6 +509,9 @@ func (a *AccountService) handleEmailUpdate(ctx context.Context, acc *model.Accou
 	if err := json.Unmarshal(b, &emailUpd); err != nil {
 		return ErrInvalidEmailUpdatePayload
 	}
+	// Canonicalize before validation so a whitespace-padded or mixed-case
+	// address passes the "email" tag and is stored in its normalized form.
+	emailUpd.NewEmail = validator.NormalizeEmail(emailUpd.NewEmail)
 	// Run validator tag checks if validator is available (API layer normally guarantees this)
 	if a.Validate != nil {
 		if err = a.Validate.Struct(emailUpd); err != nil {
@@ -531,7 +534,9 @@ func (a *AccountService) handleEmailUpdate(ctx context.Context, acc *model.Accou
 	if emailUpd.NewEmail == "" {
 		return ErrInvalidNewEmail
 	}
-	// Check if new email is same as current email
+	// Check if new email is same as current email. NewEmail is normalized
+	// above; EqualFold additionally tolerates a legacy stored email that
+	// predates the lowercase backfill (migration 025).
 	if strings.EqualFold(emailUpd.NewEmail, acc.Email) {
 		return ErrSameEmailAddress
 	}

--- a/api/service/account/account.go
+++ b/api/service/account/account.go
@@ -554,8 +554,8 @@ func (a *AccountService) handleEmailUpdate(ctx context.Context, acc *model.Accou
 	acc.Email = emailUpd.NewEmail
 	acc.EmailVerified = false
 	filtered := make([]model.Token, 0, len(acc.Tokens))
-	for _, t := range acc.Tokens { // remove any previous email verification tokens
-		if t.Type != EmailCategoryVerificationOTP {
+	for _, t := range acc.Tokens {
+		if t.Type != EmailCategoryVerificationOTP && t.Type != auth.TokenTypePasswordReset {
 			filtered = append(filtered, t)
 		}
 	}

--- a/api/service/account/account.go
+++ b/api/service/account/account.go
@@ -540,6 +540,16 @@ func (a *AccountService) handleEmailUpdate(ctx context.Context, acc *model.Accou
 	if strings.EqualFold(emailUpd.NewEmail, acc.Email) {
 		return ErrSameEmailAddress
 	}
+
+	existing, err := a.AccountRepository.GetAccountByEmail(ctx, emailUpd.NewEmail)
+	switch {
+	case err == nil && existing.ID != acc.ID:
+		return ErrEmailAlreadyInUse
+	case err == nil:
+		return ErrSameEmailAddress
+	case !errors.Is(err, dbErrors.ErrAccountNotFound):
+		return err
+	}
 	// Reset verification state and tokens
 	acc.Email = emailUpd.NewEmail
 	acc.EmailVerified = false

--- a/api/service/account/error.go
+++ b/api/service/account/error.go
@@ -55,6 +55,7 @@ var (
 	ErrInvalidCurrentPassword = reauth.ErrInvalidPassword
 	ErrInvalidNewEmail        = NewServiceAccountError("invalid new email")
 	ErrSameEmailAddress       = NewServiceAccountError("new email address is the same as the current one")
+	ErrEmailAlreadyInUse      = NewServiceAccountError("Unable to complete your request. Please try a different email address.")
 
 	// Reauth sentinels are re-exported from internal/reauth so the unified
 	// helper and every legacy call site refer to the same error values. These

--- a/api/service/account/reauth_test.go
+++ b/api/service/account/reauth_test.go
@@ -75,6 +75,38 @@ func (suite *ReauthTokenSuite) TestEmailChangeWithReauthToken() {
 	suite.Contains(acc.Email, "new@example.com")
 }
 
+// specRef: api-endpoint-behaviour.md B3, B6
+func (suite *ReauthTokenSuite) TestEmailChangeNormalizesNewEmail() {
+	acc := suite.newAccount("user@example.com")
+	acc.MFA = model.MFASettings{TOTP: model.TotpSettings{Enabled: true, Secret: "SECRET"}}
+	tok := model.Token{Type: "reauth_email_change", Value: "token-norm", ExpiresAt: time.Now().Add(2 * time.Minute)}
+	acc.Tokens = []model.Token{tok}
+
+	suite.mockAccountRepo.On("GetAccountById", context.Background(), acc.ID.Hex()).Return(acc, nil)
+	suite.mockAccountRepo.On("UpdateAccount", context.Background(), mock.AnythingOfType("*model.Account")).Return(acc, nil)
+
+	updates := []model.AccountUpdate{{Operation: "replace", Path: "/email", Value: map[string]any{"new_email": " New.Address@Example.COM ", "reauth_token": tok.Value}}}
+	err := suite.service.UpdateAccount(context.Background(), acc.ID.Hex(), updates, nil)
+	suite.Require().NoError(err)
+
+	suite.Equal("new.address@example.com", acc.Email, "stored email must be canonical lowercase")
+}
+
+// specRef: api-endpoint-behaviour.md B3
+func (suite *ReauthTokenSuite) TestEmailChangeSameEmailDifferentCase() {
+	acc := suite.newAccount("user@example.com")
+	acc.MFA = model.MFASettings{TOTP: model.TotpSettings{Enabled: true, Secret: "SECRET"}}
+	tok := model.Token{Type: "reauth_email_change", Value: "token-same", ExpiresAt: time.Now().Add(2 * time.Minute)}
+	acc.Tokens = []model.Token{tok}
+
+	suite.mockAccountRepo.On("GetAccountById", context.Background(), acc.ID.Hex()).Return(acc, nil)
+
+	updates := []model.AccountUpdate{{Operation: "replace", Path: "/email", Value: map[string]any{"new_email": "USER@Example.com", "reauth_token": tok.Value}}}
+	err := suite.service.UpdateAccount(context.Background(), acc.ID.Hex(), updates, nil)
+	suite.Require().Error(err)
+	suite.ErrorIs(err, account.ErrSameEmailAddress)
+}
+
 func (suite *ReauthTokenSuite) TestEmailChangeWithExpiredReauthToken() {
 	acc := suite.newAccount("user@example.com")
 	acc.MFA = model.MFASettings{TOTP: model.TotpSettings{Enabled: true, Secret: "SECRET"}}

--- a/api/service/account/reauth_test.go
+++ b/api/service/account/reauth_test.go
@@ -132,6 +132,31 @@ func (suite *ReauthTokenSuite) TestEmailChangeToAddressAlreadyInUse() {
 	suite.Equal("user@example.com", acc.Email, "email must remain unchanged on duplicate rejection")
 }
 
+// specRef: api-endpoint-behaviour.md B3, C2
+func (suite *ReauthTokenSuite) TestEmailChangeInvalidatesPasswordResetTokens() {
+	acc := suite.newAccount("user@example.com")
+	acc.MFA = model.MFASettings{TOTP: model.TotpSettings{Enabled: true, Secret: "SECRET"}}
+	reauthTok := model.Token{Type: "reauth_email_change", Value: "token-inv", ExpiresAt: time.Now().Add(2 * time.Minute)}
+	resetTok := model.Token{Type: "password_reset", Value: "reset-pending", ExpiresAt: time.Now().Add(30 * time.Minute)}
+	unrelatedTok := model.Token{Type: "reauth_profile_export", Value: "export-tok", ExpiresAt: time.Now().Add(2 * time.Minute)}
+	acc.Tokens = []model.Token{reauthTok, resetTok, unrelatedTok}
+
+	suite.mockAccountRepo.On("GetAccountById", context.Background(), acc.ID.Hex()).Return(acc, nil)
+	suite.mockAccountRepo.On("GetAccountByEmail", context.Background(), "fresh@example.com").Return(nil, dbErrors.ErrAccountNotFound)
+	suite.mockAccountRepo.On("UpdateAccount", context.Background(), mock.AnythingOfType("*model.Account")).Return(acc, nil)
+
+	updates := []model.AccountUpdate{{Operation: "replace", Path: "/email", Value: map[string]any{"new_email": "fresh@example.com", "reauth_token": reauthTok.Value}}}
+	err := suite.service.UpdateAccount(context.Background(), acc.ID.Hex(), updates, nil)
+	suite.Require().NoError(err)
+
+	types := make([]string, 0, len(acc.Tokens))
+	for _, t := range acc.Tokens {
+		types = append(types, t.Type)
+	}
+	suite.NotContains(types, "password_reset", "pending reset token must not survive the email change")
+	suite.Contains(types, "reauth_profile_export", "non-mailbox-bound tokens must survive")
+}
+
 func (suite *ReauthTokenSuite) TestEmailChangeWithExpiredReauthToken() {
 	acc := suite.newAccount("user@example.com")
 	acc.MFA = model.MFASettings{TOTP: model.TotpSettings{Enabled: true, Secret: "SECRET"}}

--- a/api/service/account/reauth_test.go
+++ b/api/service/account/reauth_test.go
@@ -7,6 +7,7 @@ import (
 
 	validatorv10 "github.com/go-playground/validator/v10"
 	"github.com/ivpn/dns/api/config"
+	dbErrors "github.com/ivpn/dns/api/db/errors"
 	webhookClient "github.com/ivpn/dns/api/internal/client"
 	"github.com/ivpn/dns/api/mocks"
 	"github.com/ivpn/dns/api/model"
@@ -65,6 +66,8 @@ func (suite *ReauthTokenSuite) TestEmailChangeWithReauthToken() {
 
 	// Mock GetAccountById
 	suite.mockAccountRepo.On("GetAccountById", context.Background(), acc.ID.Hex()).Return(acc, nil)
+	// Duplicate pre-check finds no existing account for the new address
+	suite.mockAccountRepo.On("GetAccountByEmail", context.Background(), "new@example.com").Return(nil, dbErrors.ErrAccountNotFound)
 	// Expect persistence on success path
 	suite.mockAccountRepo.On("UpdateAccount", context.Background(), mock.AnythingOfType("*model.Account")).Return(acc, nil)
 
@@ -83,6 +86,8 @@ func (suite *ReauthTokenSuite) TestEmailChangeNormalizesNewEmail() {
 	acc.Tokens = []model.Token{tok}
 
 	suite.mockAccountRepo.On("GetAccountById", context.Background(), acc.ID.Hex()).Return(acc, nil)
+	// Duplicate pre-check runs on the normalized address
+	suite.mockAccountRepo.On("GetAccountByEmail", context.Background(), "new.address@example.com").Return(nil, dbErrors.ErrAccountNotFound)
 	suite.mockAccountRepo.On("UpdateAccount", context.Background(), mock.AnythingOfType("*model.Account")).Return(acc, nil)
 
 	updates := []model.AccountUpdate{{Operation: "replace", Path: "/email", Value: map[string]any{"new_email": " New.Address@Example.COM ", "reauth_token": tok.Value}}}
@@ -105,6 +110,26 @@ func (suite *ReauthTokenSuite) TestEmailChangeSameEmailDifferentCase() {
 	err := suite.service.UpdateAccount(context.Background(), acc.ID.Hex(), updates, nil)
 	suite.Require().Error(err)
 	suite.ErrorIs(err, account.ErrSameEmailAddress)
+}
+
+// specRef: api-endpoint-behaviour.md B3, B7
+func (suite *ReauthTokenSuite) TestEmailChangeToAddressAlreadyInUse() {
+	acc := suite.newAccount("user@example.com")
+	acc.MFA = model.MFASettings{TOTP: model.TotpSettings{Enabled: true, Secret: "SECRET"}}
+	tok := model.Token{Type: "reauth_email_change", Value: "token-dup", ExpiresAt: time.Now().Add(2 * time.Minute)}
+	acc.Tokens = []model.Token{tok}
+
+	other := suite.newAccount("taken@example.com")
+
+	suite.mockAccountRepo.On("GetAccountById", context.Background(), acc.ID.Hex()).Return(acc, nil)
+	suite.mockAccountRepo.On("GetAccountByEmail", context.Background(), "taken@example.com").Return(other, nil)
+	// No UpdateAccount call expected: the duplicate is rejected before persistence.
+
+	updates := []model.AccountUpdate{{Operation: "replace", Path: "/email", Value: map[string]any{"new_email": "taken@example.com", "reauth_token": tok.Value}}}
+	err := suite.service.UpdateAccount(context.Background(), acc.ID.Hex(), updates, nil)
+	suite.Require().Error(err)
+	suite.ErrorIs(err, account.ErrEmailAlreadyInUse)
+	suite.Equal("user@example.com", acc.Email, "email must remain unchanged on duplicate rejection")
 }
 
 func (suite *ReauthTokenSuite) TestEmailChangeWithExpiredReauthToken() {

--- a/api/service/account/service_test.go
+++ b/api/service/account/service_test.go
@@ -830,6 +830,14 @@ func (suite *AccountTestSuite) TestUpdateAccount() {
 				} else {
 					suite.mockAccountRepo.On("GetAccountById", context.Background(), tt.accountID).Return(tt.account, nil)
 
+					// Email-change duplicate pre-check: address is free
+					for _, update := range tt.updates {
+						if update.Path == "/email" {
+							suite.mockAccountRepo.On("GetAccountByEmail", context.Background(), mock.AnythingOfType("string")).Return(nil, dbErrors.ErrAccountNotFound).Maybe()
+							break
+						}
+					}
+
 					if tt.expectedErr == account.ErrInvalidTOTPCode && tt.account != nil {
 						key := "totp_fails:" + tt.account.ID.Hex()
 						suite.mockCache.On("Incr", mock.Anything, key, suite.serviceConfig.IdLimiterExpiration).Return(int64(1), nil)
@@ -2665,6 +2673,14 @@ func (suite *AccountTestSuite) TestUpdateAccountWith2FA() {
 				} else {
 					// First GetAccountById for the main update
 					suite.mockAccountRepo.On("GetAccountById", context.Background(), tt.accountID).Return(tt.account, nil).Once()
+
+					// Email-change duplicate pre-check: address is free
+					for _, update := range tt.updates {
+						if update.Path == "/email" {
+							suite.mockAccountRepo.On("GetAccountByEmail", context.Background(), mock.AnythingOfType("string")).Return(nil, dbErrors.ErrAccountNotFound).Maybe()
+							break
+						}
+					}
 
 					// Setup mocks for MFA verification if account has TOTP enabled
 					if tt.account.MFA.TOTP.Enabled && tt.mfa != nil && tt.mfa.OTP != "" {

--- a/app/env/.env.production
+++ b/app/env/.env.production
@@ -7,7 +7,7 @@ VITE_DNS_SERVER_IPV6_ADDRESSES=2a03:c040::5
 VITE_SENTRY_DSN=
 VITE_SENTRY_RELEASE=
 VITE_SENTRY_ENVIRONMENT=production
-VITE_DNS_SERVER_LOCATIONS="ams1:Amsterdam,tor1:Toronto,ssg1:Singapore,syd1:Sydney,lax1:Los Angeles,nys1:New York"
+VITE_DNS_SERVER_LOCATIONS="ams1|Amsterdam|185.229.190.69|2a02:6ea0:100a::1,tor1|Toronto|198.44.157.3|2607:9000:600:24::2,ssg1|Singapore|135.136.8.38|2001:ac8:94:6::2,syd1|Sydney|135.136.9.10|2001:ac8:84:67::2,lax1|Los Angeles|107.155.127.138|2604:4500:8:2b::2,nys1|New York|66.165.235.218|2604:4500:9:1e::2"
 VITE_RESYNC_URL=https://www.ivpn.net/en/account/
 
 # Base URL for the IVPN marketing site — all IVPN links on the public landing page derive from this.

--- a/app/env/.env.staging
+++ b/app/env/.env.staging
@@ -7,7 +7,7 @@ VITE_DNS_SERVER_IPV6_ADDRESSES=2607:5300:203:9cc9::178
 VITE_SENTRY_DSN=
 VITE_SENTRY_RELEASE=
 VITE_SENTRY_ENVIRONMENT=staging
-VITE_DNS_SERVER_LOCATIONS="vm1:Quebec"
+VITE_DNS_SERVER_LOCATIONS="vm1|Quebec|51.161.64.178|2607:5300:203:9cc9::178"
 VITE_RESYNC_URL=https://staging.tamazaki.com/en/account/
 
 # Base URL for the IVPN marketing site — all IVPN links on the public landing page derive from this.

--- a/app/env/.env.test
+++ b/app/env/.env.test
@@ -8,7 +8,7 @@ VITE_DNS_SERVER_IPV6_ADDRESSES=2607:5300:203:9cc9::178
 VITE_SENTRY_DSN=
 VITE_SENTRY_RELEASE=
 VITE_SENTRY_ENVIRONMENT=test
-VITE_DNS_SERVER_LOCATIONS="ams1:Amsterdam,tor1:Toronto,ssg1:Singapore,syd1:Sydney,lax1:Los Angeles,nys1:New York"
+VITE_DNS_SERVER_LOCATIONS="ams1|Amsterdam|185.229.190.69|2a02:6ea0:100a::1,tor1|Toronto|198.44.157.3|2607:9000:600:24::2,ssg1|Singapore|135.136.8.38|2001:ac8:94:6::2,syd1|Sydney|135.136.9.10|2001:ac8:84:67::2,lax1|Los Angeles|107.155.127.138|2604:4500:8:2b::2,nys1|New York|66.165.235.218|2604:4500:9:1e::2"
 VITE_RESYNC_URL=https://www.ivpn.net/en/account/
 
 # Base URL for the IVPN marketing site — all IVPN links on the public landing page derive from this.

--- a/app/src/__tests__/e2e/account/changeEmail.spec.ts
+++ b/app/src/__tests__/e2e/account/changeEmail.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+
+const mockAccount = {
+  account_id: 'abc',
+  email: 'old@example.com',
+  email_verified: true,
+  auth_methods: ['password'],
+  mfa: { totp: { enabled: false } },
+};
+
+const setupRoutes = async (
+  page: import('@playwright/test').Page,
+  onPatch: (body: string | null) => void,
+) => {
+  await page.addInitScript(() => { window.localStorage.setItem('AUTH_KEY', 'true'); });
+  await page.route('**/api/v1/accounts', async route => {
+    if (route.request().method() === 'PATCH') {
+      onPatch(route.request().postData());
+      return route.fulfill({ status: 200, body: '' });
+    }
+    return route.continue();
+  });
+  await page.route('**/api/v1/accounts/current', async route => {
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockAccount) });
+  });
+  await page.route('**/api/v1/webauthn/passkeys', async route => {
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+  await page.route('**/api/v1/profiles', async route => {
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+};
+
+// Happy path: two-step flow shows the lockout warning, tolerates a
+// casing/whitespace variant in the confirm entry, and sends the PATCH.
+test('email change requires confirm step and sends patch on match', async ({ page }) => {
+  let patchBody: string | null = null;
+  await setupRoutes(page, body => { patchBody = body; });
+  await page.goto('http://localhost:5173/account-preferences');
+
+  const changeBtn = page.getByRole('button', { name: /Change email/i });
+  const isVisible = await changeBtn.isVisible().catch(() => false);
+  if (!isVisible) {
+    test.skip(true, 'Change email button not reachable - app server likely not started');
+    return;
+  }
+  await changeBtn.click();
+
+  await page.getByPlaceholder('new@example.com').fill('new@example.com');
+  await page.getByPlaceholder('••••••••').fill('Password123!');
+  await page.getByRole('button', { name: /^Continue$/ }).click();
+
+  // Confirm step: warning about non-deliverable address is visible, no PATCH yet.
+  await expect(page.getByTestId('confirm-email-warning')).toBeVisible();
+  await expect(page.getByTestId('confirm-email-warning')).toContainText(/password reset/i);
+  expect(patchBody).toBeNull();
+
+  await page.getByTestId('input-confirm-email').fill(' NEW@Example.com ');
+  await page.getByRole('button', { name: /Update email/i }).click();
+
+  await expect.poll(() => patchBody).not.toBeNull();
+  const payload = JSON.parse(patchBody!) as { updates: { operation: string; path: string; value: { new_email: string } }[] };
+  expect(payload.updates).toHaveLength(1);
+  expect(payload.updates[0].path).toBe('/email');
+  expect(payload.updates[0].value.new_email).toBe('new@example.com');
+});
+
+// Negative flow: mismatching confirm entry blocks submit and no PATCH is sent.
+test('email change blocked while confirm entry mismatches', async ({ page }) => {
+  let patchCalled = false;
+  await setupRoutes(page, () => { patchCalled = true; });
+  await page.goto('http://localhost:5173/account-preferences');
+
+  const changeBtn = page.getByRole('button', { name: /Change email/i });
+  const isVisible = await changeBtn.isVisible().catch(() => false);
+  if (!isVisible) {
+    test.skip(true, 'Change email button not reachable - app server likely not started');
+    return;
+  }
+  await changeBtn.click();
+
+  await page.getByPlaceholder('new@example.com').fill('new@example.com');
+  await page.getByPlaceholder('••••••••').fill('Password123!');
+  await page.getByRole('button', { name: /^Continue$/ }).click();
+
+  await page.getByTestId('input-confirm-email').fill('wrong@example.com');
+  await expect(page.getByTestId('confirm-email-mismatch')).toBeVisible();
+  await expect(page.getByRole('button', { name: /Update email/i })).toBeDisabled();
+  await page.waitForTimeout(300);
+  expect(patchCalled).toBeFalsy();
+});

--- a/app/src/__tests__/unit/ChangeEmailDialog.test.tsx
+++ b/app/src/__tests__/unit/ChangeEmailDialog.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ChangeEmailDialog from '@/pages/account_preferences/ChangeEmailDialog';
 import type { ModelAccount, ModelCredential } from '@/api/client/api';
 import { useAppStore } from '@/store/general';
+import api from '@/api/api';
 
 vi.mock('@/api/api', () => {
     return {
@@ -22,26 +23,19 @@ vi.mock('@/api/api', () => {
 // simple helper to access store
 const getAccount = () => useAppStore.getState().account;
 
+// Fill step 1 (password method) and advance to the confirm step.
+const fillDetailsAndContinue = () => {
+    fireEvent.click(screen.getByText('Password'));
+    fireEvent.change(screen.getByPlaceholderText('new@example.com'), { target: { value: 'new@example.com' } });
+    fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByText('Continue'));
+};
+
 describe('ChangeEmailDialog', () => {
     beforeEach(() => {
+        vi.mocked(api.Client.accountsApi.apiV1AccountsPatch).mockClear();
         useAppStore.getState().setAccount({ email: 'old@example.com', email_verified: true } as ModelAccount);
         useAppStore.getState().setPasskeys([]);
-    });
-
-    it('submits change and refreshes account', async () => {
-        const onChanged = vi.fn();
-        render(<ChangeEmailDialog open account={getAccount()} onOpenChange={() => { }} onChanged={onChanged} />);
-        // Switch to password method (default is passkey now)
-        fireEvent.click(screen.getByText('Password'));
-
-        fireEvent.change(screen.getByPlaceholderText('new@example.com'), { target: { value: 'new@example.com' } });
-        fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'password123' } });
-
-        fireEvent.click(screen.getByText('Update email'));
-
-        await waitFor(() => expect(onChanged).toHaveBeenCalled());
-        expect(getAccount()?.email).toBe('new@example.com');
-        expect(getAccount()?.email_verified).toBe(false);
     });
 
     it('prefers passkey verification when available', () => {
@@ -52,5 +46,55 @@ describe('ChangeEmailDialog', () => {
 
         expect(screen.getByText('Verify with passkey')).toBeInTheDocument();
         expect(screen.queryByLabelText('Current password')).not.toBeInTheDocument();
+    });
+
+    it('advances to a confirm step that shows the lockout warning', () => {
+        render(<ChangeEmailDialog open account={getAccount()} onOpenChange={() => { }} onChanged={() => { }} />);
+        fillDetailsAndContinue();
+
+        expect(screen.getByTestId('input-confirm-email')).toBeInTheDocument();
+        const warning = screen.getByTestId('confirm-email-warning');
+        expect(warning.textContent).toMatch(/password reset/i);
+        expect(warning.textContent).toMatch(/lose access|locked out/i);
+        // Submit must not have fired yet.
+        expect(api.Client.accountsApi.apiV1AccountsPatch).not.toHaveBeenCalled();
+    });
+
+    it('submits only after the confirm entry matches (case/whitespace-insensitive)', async () => {
+        const onChanged = vi.fn();
+        render(<ChangeEmailDialog open account={getAccount()} onOpenChange={() => { }} onChanged={onChanged} />);
+        fillDetailsAndContinue();
+
+        // A casing/padding variant of the same address counts as a match.
+        fireEvent.change(screen.getByTestId('input-confirm-email'), { target: { value: ' NEW@Example.com ' } });
+        fireEvent.click(screen.getByText('Update email'));
+
+        await waitFor(() => expect(onChanged).toHaveBeenCalled());
+        expect(api.Client.accountsApi.apiV1AccountsPatch).toHaveBeenCalledTimes(1);
+        expect(getAccount()?.email).toBe('new@example.com');
+        expect(getAccount()?.email_verified).toBe(false);
+    });
+
+    it('blocks submit and shows an error while the confirm entry mismatches', () => {
+        render(<ChangeEmailDialog open account={getAccount()} onOpenChange={() => { }} onChanged={() => { }} />);
+        fillDetailsAndContinue();
+
+        fireEvent.change(screen.getByTestId('input-confirm-email'), { target: { value: 'wrong@example.com' } });
+
+        expect(screen.getByTestId('confirm-email-mismatch')).toBeInTheDocument();
+        const submit = screen.getByText('Update email').closest('button');
+        expect(submit).toBeDisabled();
+        fireEvent.click(screen.getByText('Update email'));
+        expect(api.Client.accountsApi.apiV1AccountsPatch).not.toHaveBeenCalled();
+    });
+
+    it('back returns to the first step with the entered address preserved', () => {
+        render(<ChangeEmailDialog open account={getAccount()} onOpenChange={() => { }} onChanged={() => { }} />);
+        fillDetailsAndContinue();
+
+        fireEvent.click(screen.getByText('Back'));
+
+        expect(screen.getByPlaceholderText('new@example.com')).toHaveValue('new@example.com');
+        expect(screen.queryByTestId('input-confirm-email')).not.toBeInTheDocument();
     });
 });

--- a/app/src/__tests__/unit/lib/dnsServerLocations.test.ts
+++ b/app/src/__tests__/unit/lib/dnsServerLocations.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { parseDnsServerLocations, firstAddress } from '@/lib/dnsServerLocations';
+
+const DOMAIN = 'dns.example.net';
+
+describe('parseDnsServerLocations', () => {
+    it('parses prefix|City|ipv4|ipv6 entries', () => {
+        const raw = 'ams1|Amsterdam|185.229.190.69|2a02:6ea0:100a::1,lax1|Los Angeles|107.155.127.138|2604:4500:8:2b::2';
+        expect(parseDnsServerLocations(raw, DOMAIN)).toEqual([
+            { prefix: 'ams1', city: 'Amsterdam', hostname: 'ams1.dns.example.net', ipv4: '185.229.190.69', ipv6: '2a02:6ea0:100a::1' },
+            { prefix: 'lax1', city: 'Los Angeles', hostname: 'lax1.dns.example.net', ipv4: '107.155.127.138', ipv6: '2604:4500:8:2b::2' },
+        ]);
+    });
+
+    it('still accepts the legacy prefix:City format without addresses', () => {
+        expect(parseDnsServerLocations('ams1:Amsterdam,syd1:Sydney', DOMAIN)).toEqual([
+            { prefix: 'ams1', city: 'Amsterdam', hostname: 'ams1.dns.example.net', ipv4: undefined, ipv6: undefined },
+            { prefix: 'syd1', city: 'Sydney', hostname: 'syd1.dns.example.net', ipv4: undefined, ipv6: undefined },
+        ]);
+    });
+
+    it('falls back to the prefix as city and leaves blank addresses undefined', () => {
+        expect(parseDnsServerLocations('vm1|||', DOMAIN)).toEqual([
+            { prefix: 'vm1', city: 'vm1', hostname: 'vm1.dns.example.net', ipv4: undefined, ipv6: undefined },
+        ]);
+        expect(parseDnsServerLocations('vm1|Quebec|51.161.64.178', DOMAIN)[0]).toMatchObject({
+            city: 'Quebec', ipv4: '51.161.64.178', ipv6: undefined,
+        });
+        expect(parseDnsServerLocations('vm1', DOMAIN)[0]).toMatchObject({ prefix: 'vm1', city: 'vm1' });
+    });
+
+    it('trims whitespace and skips empty entries', () => {
+        expect(parseDnsServerLocations(' ams1 | Amsterdam | 1.2.3.4 | 2001:db8::1 , , tor1:Toronto ,', DOMAIN)).toEqual([
+            { prefix: 'ams1', city: 'Amsterdam', hostname: 'ams1.dns.example.net', ipv4: '1.2.3.4', ipv6: '2001:db8::1' },
+            { prefix: 'tor1', city: 'Toronto', hostname: 'tor1.dns.example.net', ipv4: undefined, ipv6: undefined },
+        ]);
+    });
+
+    it('returns an empty list for empty or undefined input', () => {
+        expect(parseDnsServerLocations('', DOMAIN)).toEqual([]);
+        expect(parseDnsServerLocations(undefined, DOMAIN)).toEqual([]);
+    });
+});
+
+describe('firstAddress', () => {
+    it('returns the first non-empty comma-separated item', () => {
+        expect(firstAddress('89.124.253.5')).toBe('89.124.253.5');
+        expect(firstAddress(' , 51.161.64.178 ,51.161.64.179')).toBe('51.161.64.178');
+    });
+
+    it('returns undefined when nothing is configured', () => {
+        expect(firstAddress('')).toBeUndefined();
+        expect(firstAddress(undefined)).toBeUndefined();
+        expect(firstAddress(' , ')).toBeUndefined();
+    });
+});

--- a/app/src/lib/dnsServerLocations.ts
+++ b/app/src/lib/dnsServerLocations.ts
@@ -1,0 +1,44 @@
+export interface DnsServerLocation {
+    prefix: string;
+    city: string;
+    hostname: string;
+    ipv4?: string;
+    ipv6?: string;
+}
+
+const nonEmpty = (value: string | undefined): string | undefined => {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+};
+
+/**
+ * Parses VITE_DNS_SERVER_LOCATIONS: comma-separated `prefix|City|ipv4|ipv6` entries.
+ * `|` is the field separator because IPv6 literals contain `:`; the older
+ * `prefix:City` form is still accepted and yields no addresses.
+ */
+export function parseDnsServerLocations(raw: string | undefined, domain: string): DnsServerLocation[] {
+    return (raw ?? '')
+        .split(',')
+        .map(entry => entry.trim())
+        .filter(Boolean)
+        .map(entry => {
+            const fields = entry.includes('|') ? entry.split('|') : entry.split(':');
+            const [prefixField, cityField, ipv4Field, ipv6Field] = fields;
+            const prefix = prefixField.trim();
+            return {
+                prefix,
+                city: nonEmpty(cityField) ?? prefix,
+                hostname: `${prefix}.${domain}`,
+                ipv4: nonEmpty(ipv4Field),
+                ipv6: nonEmpty(ipv6Field),
+            };
+        });
+}
+
+/** First non-empty item of a comma-separated address list (VITE_DNS_SERVER_IP*_ADDRESSES). */
+export function firstAddress(raw: string | undefined): string | undefined {
+    return (raw ?? '')
+        .split(',')
+        .map(item => item.trim())
+        .find(Boolean);
+}

--- a/app/src/pages/account_preferences/ChangeEmailDialog.tsx
+++ b/app/src/pages/account_preferences/ChangeEmailDialog.tsx
@@ -19,8 +19,13 @@ interface ChangeEmailDialogProps {
     onChanged: () => void; // callback after successful change
 }
 
+// Canonical comparison form, mirroring backend email normalization.
+const normalizeEmail = (s: string) => s.trim().toLowerCase();
+
 export default function ChangeEmailDialog({ open, onOpenChange, account, onChanged }: ChangeEmailDialogProps) {
+    const [step, setStep] = useState<'details' | 'confirm'>('details');
     const [newEmail, setNewEmail] = useState('');
+    const [confirmEmail, setConfirmEmail] = useState('');
     const [currentPassword, setCurrentPassword] = useState('');
     const [reauthToken, setReauthToken] = useState<string | null>(null);
     const [reauthStatus, setReauthStatus] = useState<'idle' | 'in-progress' | 'verified' | 'error'>('idle');
@@ -53,12 +58,40 @@ export default function ChangeEmailDialog({ open, onOpenChange, account, onChang
     }
     useEffect(() => {
         if (!open) {
+            setStep('details');
             setOtp('');
+            setConfirmEmail('');
             setCurrentPassword('');
             setReauthToken(null);
             setReauthStatus('idle');
         }
     }, [open]);
+
+    const emailsMatch = confirmEmail !== '' && normalizeEmail(confirmEmail) === normalizeEmail(newEmail);
+    const showMismatch = confirmEmail !== '' && !emailsMatch;
+
+    // Validate step-1 input and advance to the confirm step; the PATCH only
+    // happens from the confirm step in handleSubmit.
+    const handleContinue = () => {
+        if (!account) return;
+        if (!newEmail.includes('@')) {
+            toast.error('Please enter a valid email.');
+            return;
+        }
+        if (method === 'password' && !currentPassword) {
+            toast.error('Current password is required.');
+            return;
+        }
+        if (method === 'passkey' && !reauthToken) {
+            toast.error('Passkey verification is required.');
+            return;
+        }
+        if (showOtp && !otp) {
+            toast.error('2FA code is required.');
+            return;
+        }
+        setStep('confirm');
+    };
 
     const beginPasskeyReauth = async () => {
         if (!account) return;
@@ -79,24 +112,11 @@ export default function ChangeEmailDialog({ open, onOpenChange, account, onChang
         }
     };
 
-    // Handle email change with optional 2FA
+    // Handle email change with optional 2FA; reachable only from the confirm step.
     const handleSubmit = async () => {
         if (!account) return;
-        if (!newEmail.includes('@')) {
-            toast.error('Please enter a valid email.');
-            return;
-        }
-        if (method === 'password' && !currentPassword) {
-            toast.error('Current password is required.');
-            return;
-        }
-        if (method === 'passkey' && !reauthToken) {
-            toast.error('Passkey verification is required.');
-            return;
-        }
-        // OTP required only for password method
-        if (showOtp && !otp) {
-            toast.error('2FA code is required.');
+        if (!emailsMatch) {
+            toast.error('Email addresses do not match.');
             return;
         }
 
@@ -142,8 +162,10 @@ export default function ChangeEmailDialog({ open, onOpenChange, account, onChang
     const handleOpenChange = (next: boolean) => {
         if (!next) {
             // Reset state when closing
+            setStep('details');
             setOtp('');
             setNewEmail('');
+            setConfirmEmail('');
             setCurrentPassword('');
             setReauthToken(null);
             setReauthStatus('idle');
@@ -165,10 +187,11 @@ export default function ChangeEmailDialog({ open, onOpenChange, account, onChang
                         Change email
                     </DialogTitle>
                     <DialogDescription className="text-sm font-normal text-[var(--tailwind-colors-slate-400)] font-['Roboto_Flex-Regular',Helvetica] leading-5">
-                        Enter your new email address below.
+                        {step === 'details' ? 'Enter your new email address below.' : 'Re-enter your new email address to confirm it.'}
                     </DialogDescription>
                 </DialogHeader>
 
+                {step === 'details' && (
                 <div className="flex flex-col gap-4 px-6 pb-4">
                     <div className="flex flex-col sm:flex-row sm:items-center gap-3">
                         <div className="inline-flex text-[11px] rounded-md bg-[var(--tailwind-colors-slate-800)] p-1 shadow-sm w-full sm:w-auto">
@@ -209,7 +232,7 @@ export default function ChangeEmailDialog({ open, onOpenChange, account, onChang
                     </div>
                     <div className="space-y-2">
                         <label className="text-sm text-[var(--tailwind-colors-slate-50)] font-medium">New email</label>
-                        <Input value={newEmail} onChange={e => setNewEmail(e.target.value)} placeholder="new@example.com" autoFocus className="border-[var(--tailwind-colors-slate-700)] bg-[var(--tailwind-colors-slate-800)] text-[var(--tailwind-colors-slate-50)] h-10" />
+                        <Input value={newEmail} onChange={e => { setNewEmail(e.target.value); setConfirmEmail(''); }} placeholder="new@example.com" autoFocus className="border-[var(--tailwind-colors-slate-700)] bg-[var(--tailwind-colors-slate-800)] text-[var(--tailwind-colors-slate-50)] h-10" />
                     </div>
                     {method === 'password' && (
                         <div className="space-y-2">
@@ -257,7 +280,7 @@ export default function ChangeEmailDialog({ open, onOpenChange, account, onChang
                                 onChange={e => setOtp(e.target.value)}
                                 onKeyDown={e => {
                                     if (e.key === 'Enter') {
-                                        handleSubmit();
+                                        handleContinue();
                                     }
                                 }}
                                 className="border-[var(--tailwind-colors-slate-700)] bg-[var(--tailwind-colors-slate-800)] text-[var(--tailwind-colors-slate-50)] h-10"
@@ -267,32 +290,73 @@ export default function ChangeEmailDialog({ open, onOpenChange, account, onChang
                     )}
                     <p className="text-xs text-[var(--tailwind-colors-slate-400)]">After changing your email it will be unverified until you complete the new verification OTP process.</p>
                 </div>
+                )}
+
+                {step === 'confirm' && (
+                <div className="flex flex-col gap-4 px-6 pb-4">
+                    <div className="space-y-2">
+                        <label className="text-sm text-[var(--tailwind-colors-slate-50)] font-medium">Confirm new email</label>
+                        <Input
+                            data-testid="input-confirm-email"
+                            value={confirmEmail}
+                            onChange={e => setConfirmEmail(e.target.value)}
+                            onKeyDown={e => {
+                                if (e.key === 'Enter' && emailsMatch && !submitting) {
+                                    handleSubmit();
+                                }
+                            }}
+                            placeholder="Re-enter your new email"
+                            autoFocus
+                            className="border-[var(--tailwind-colors-slate-700)] bg-[var(--tailwind-colors-slate-800)] text-[var(--tailwind-colors-slate-50)] h-10"
+                        />
+                        {showMismatch && (
+                            <p data-testid="confirm-email-mismatch" className="text-xs text-[var(--tailwind-colors-red-400)]">
+                                Email addresses do not match.
+                            </p>
+                        )}
+                    </div>
+                    <p
+                        data-testid="confirm-email-warning"
+                        className="text-xs leading-5 text-[var(--tailwind-colors-amber-400,#fbbf24)] rounded-md border border-[#fbbf24]/30 bg-[#fbbf24]/10 p-3"
+                    >
+                        Make sure this address is real and you can receive mail at it. If it has a typo or doesn't
+                        exist, verification and password reset emails will never reach you — and you could lose
+                        access to your account.
+                    </p>
+                </div>
+                )}
 
                 <DialogActions>
                     <Button
                         variant="cancel"
                         size="lg"
                         className="flex-1 min-w-32 font-medium"
-                        onClick={() => handleOpenChange(false)}
+                        onClick={() => step === 'confirm' ? setStep('details') : handleOpenChange(false)}
                         disabled={submitting}
                     >
-                        Cancel
+                        {step === 'confirm' ? 'Back' : 'Cancel'}
                     </Button>
-                    <Button
-                        variant="default"
-                        size="lg"
-                        className="flex-1 min-w-32 bg-[var(--tailwind-colors-rdns-600)] text-[var(--tailwind-colors-slate-900)] hover:!bg-[var(--tailwind-colors-rdns-800)]"
-                        onClick={handleSubmit}
-                        disabled={submitting || (method === 'passkey' && reauthStatus !== 'verified') || (showOtp && !otp)}
-                    >
-                        {submitting
-                            ? 'Updating...'
-                            : method === 'passkey'
-                                ? (reauthStatus === 'verified'
-                                    ? (showOtp ? 'Update email' : 'Update email')
-                                    : 'Verify passkey first')
-                                : 'Update email'}
-                    </Button>
+                    {step === 'details' ? (
+                        <Button
+                            variant="default"
+                            size="lg"
+                            className="flex-1 min-w-32 bg-[var(--tailwind-colors-rdns-600)] text-[var(--tailwind-colors-slate-900)] hover:!bg-[var(--tailwind-colors-rdns-800)]"
+                            onClick={handleContinue}
+                            disabled={submitting || (method === 'passkey' && reauthStatus !== 'verified') || (showOtp && !otp)}
+                        >
+                            {method === 'passkey' && reauthStatus !== 'verified' ? 'Verify passkey first' : 'Continue'}
+                        </Button>
+                    ) : (
+                        <Button
+                            variant="default"
+                            size="lg"
+                            className="flex-1 min-w-32 bg-[var(--tailwind-colors-rdns-600)] text-[var(--tailwind-colors-slate-900)] hover:!bg-[var(--tailwind-colors-rdns-800)]"
+                            onClick={handleSubmit}
+                            disabled={submitting || !emailsMatch}
+                        >
+                            {submitting ? 'Updating...' : 'Update email'}
+                        </Button>
+                    )}
                 </DialogActions>
             </DialogContent>
         </Dialog>

--- a/app/src/pages/legal/FAQ.tsx
+++ b/app/src/pages/legal/FAQ.tsx
@@ -7,6 +7,7 @@ import modDNSLogoDarkTheme from '@/assets/logos/modDNS-dark-theme.svg';
 import modDNSLogoLightTheme from '@/assets/logos/modDNS-light-theme.svg';
 import { useTheme } from "@/components/theme-provider";
 import AuthFooter from "@/components/auth/AuthFooter";
+import { parseDnsServerLocations, firstAddress } from "@/lib/dnsServerLocations";
 
 interface FAQItemProps {
     question: string;
@@ -99,7 +100,10 @@ function FAQSection({ title, children, globalToggleSignal, globalToggleState }: 
     );
 }
 
-const FAQ_LAST_UPDATED = 'June 1, 2026';
+const FAQ_LAST_UPDATED = 'September 3, 2026';
+
+const CODE_CLASS = "text-[var(--shadcn-ui-app-foreground)] px-2 py-0.5 rounded text-sm font-mono border border-[var(--shadcn-ui-app-border)]";
+const TABLE_CELL_CLASS = "border border-[var(--shadcn-ui-app-border)] px-3 py-2 text-left align-top";
 
 export default function FAQ(): JSX.Element {
     const navigate = useNavigate();
@@ -276,34 +280,50 @@ export default function FAQ(): JSX.Element {
         </div>
     );
 
-    const dnsDomain = (import.meta as ImportMeta).env.VITE_DNS_SERVER_DOMAIN || 'dns.moddns.net';
-    const locationsRaw: string = (import.meta as ImportMeta).env.VITE_DNS_SERVER_LOCATIONS || '';
-    const serverLocations = locationsRaw
-        .split(',')
-        .map(entry => entry.trim())
-        .filter(Boolean)
-        .map(entry => {
-            const [prefix, city] = entry.split(':');
-            return { hostname: `${prefix}.${dnsDomain}`, city: city || prefix };
-        });
+    const dnsEnv = (import.meta as ImportMeta).env;
+    const dnsDomain = dnsEnv.VITE_DNS_SERVER_DOMAIN || 'dns.moddns.net';
+    const serverLocations = parseDnsServerLocations(dnsEnv.VITE_DNS_SERVER_LOCATIONS, dnsDomain);
+    const anycastRow = {
+        city: 'Anycast (default)',
+        hostname: dnsDomain,
+        ipv4: firstAddress(dnsEnv.VITE_DNS_SERVER_IP_ADDRESSES),
+        ipv6: firstAddress(dnsEnv.VITE_DNS_SERVER_IPV6_ADDRESSES),
+    };
+    const serverRows = [anycastRow, ...serverLocations];
+    const showIpv6Column = serverRows.some(row => row.ipv6);
 
     const canIChooseServer = (
         <div className="space-y-2">
             <p>By default, modDNS uses anycast routing to automatically direct your queries to the nearest server. In most cases, this gives you the lowest latency and automatic failover without any configuration.</p>
-            <p>Each server location also has a location-specific hostname that can be used directly if you want to pin your queries to a specific node, if necessary.</p>
+            <p>Each server location also has a location-specific hostname and its own IP addresses that can be used directly if you want to pin your queries to a specific server. This can help if queries are slow or time out with the default anycast setup, for example when you connect through a VPN server in another region and anycast routes you to a distant location.</p>
             <p>Note: if you opt to use a specific endpoint directly, in case of maintenance of the server resolutions will stop. Unless you have a very good reason to pick this option, we recommend going with the default anycast setup.</p>
             {serverLocations.length > 0 && (
-                <div>
+                <div className="space-y-2">
                     <p>Currently available locations:</p>
-                    <ul className="list-disc pl-5 space-y-1">
-                        {serverLocations.map(loc => (
-                            <li key={loc.hostname}>
-                                <code className="text-[var(--shadcn-ui-app-foreground)] px-2 py-0.5 rounded text-sm font-mono border border-[var(--shadcn-ui-app-border)]">{loc.hostname}</code> — {loc.city}
-                            </li>
-                        ))}
-                    </ul>
-                    <br />
-                    <p>To use a location-specific endpoint, prepend your Profile ID to the server hostname. For example, if your Profile ID is <code className="text-[var(--shadcn-ui-app-foreground)] px-2 py-0.5 rounded text-sm font-mono border border-[var(--shadcn-ui-app-border)]">abc123</code> and you want to use the {serverLocations[0]?.city} server, configure your DNS-over-TLS/QUIC hostname as <code className="text-[var(--shadcn-ui-app-foreground)] px-2 py-0.5 rounded text-sm font-mono border border-[var(--shadcn-ui-app-border)]">abc123.{serverLocations[0]?.hostname}</code>.</p>
+                    <div className="overflow-x-auto">
+                        <table className="w-full border-collapse text-sm">
+                            <thead>
+                                <tr>
+                                    <th className={TABLE_CELL_CLASS}>Location</th>
+                                    <th className={TABLE_CELL_CLASS}>Hostname</th>
+                                    <th className={TABLE_CELL_CLASS}>IPv4</th>
+                                    {showIpv6Column && <th className={TABLE_CELL_CLASS}>IPv6</th>}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {serverRows.map(row => (
+                                    <tr key={row.hostname}>
+                                        <td className={`${TABLE_CELL_CLASS} whitespace-nowrap`}>{row.city}</td>
+                                        <td className={`${TABLE_CELL_CLASS} font-mono whitespace-nowrap`}>{row.hostname}</td>
+                                        <td className={`${TABLE_CELL_CLASS} font-mono whitespace-nowrap`}>{row.ipv4 ?? '—'}</td>
+                                        {showIpv6Column && <td className={`${TABLE_CELL_CLASS} font-mono whitespace-nowrap`}>{row.ipv6 ?? '—'}</td>}
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                    <p>To use a location-specific endpoint, prepend your Profile ID to the server hostname. For example, if your Profile ID is <code className={CODE_CLASS}>abc123</code> and you want to use the {serverLocations[0]?.city} server, configure your DNS-over-TLS/QUIC hostname as <code className={CODE_CLASS}>abc123.{serverLocations[0]?.hostname}</code>.</p>
+                    <p>Some clients (Apple configuration profiles, routers, systemd-resolved, stubby) also ask for the server's IP address alongside the hostname. In that case use the IPv4 or IPv6 address listed for the <strong>same location</strong>. If you enter the anycast address there, your queries are still routed by anycast regardless of the hostname.</p>
                 </div>
             )}
             <p>Your filtering settings, blocklists, and custom rules are synchronized across all servers, so your experience is identical regardless of which server handles your query.</p>

--- a/app/src/pages/legal/FAQ.tsx
+++ b/app/src/pages/legal/FAQ.tsx
@@ -2,7 +2,8 @@ import React, { type JSX, useState, useRef, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { ArrowLeft, ChevronDown } from "lucide-react";
+import { ArrowLeft, Check, ChevronDown, Clipboard } from "lucide-react";
+import { toast } from "sonner";
 import modDNSLogoDarkTheme from '@/assets/logos/modDNS-dark-theme.svg';
 import modDNSLogoLightTheme from '@/assets/logos/modDNS-light-theme.svg';
 import { useTheme } from "@/components/theme-provider";
@@ -113,8 +114,51 @@ const FAQ_LAST_UPDATED = 'September 3, 2026';
 
 const CODE_CLASS = "text-[var(--shadcn-ui-app-foreground)] px-2 py-0.5 rounded text-sm font-mono border border-[var(--shadcn-ui-app-border)]";
 const TABLE_CELL_CLASS = "border border-[var(--shadcn-ui-app-border)] px-3 py-2 text-left align-top";
-const TERM_CLASS = "text-xs uppercase tracking-wide text-[var(--shadcn-ui-app-muted-foreground)]";
-const VALUE_CLASS = "min-w-0 break-all font-mono select-all";
+const TERM_CLASS = "block text-xs uppercase tracking-wide text-[var(--shadcn-ui-app-muted-foreground)]";
+const VALUE_CLASS = "block min-w-0 break-all font-mono";
+
+interface CopyRowProps {
+    label: string;
+    value: string;
+}
+
+/** Tap-to-copy label/value row for the narrow-screen server cards (mirrors the setup page rows). */
+function CopyRow({ label, value }: CopyRowProps) {
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        if (!copied) return;
+        const timer = setTimeout(() => setCopied(false), 1600);
+        return () => clearTimeout(timer);
+    }, [copied]);
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(value);
+            setCopied(true);
+            toast.success(`${label} copied to clipboard`);
+        } catch {
+            toast.error('Copy failed');
+        }
+    };
+
+    return (
+        <button
+            type="button"
+            onClick={handleCopy}
+            className="block w-full min-h-10 rounded-md px-2 py-1 -mx-2 text-left active:bg-[var(--shadcn-ui-app-muted)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+            <span className="sr-only">Copy </span>
+            <span className="flex items-center justify-between gap-3">
+                <span className={TERM_CLASS}>{label}</span>
+                {copied
+                    ? <Check className="h-4 w-4 shrink-0 text-[var(--tailwind-colors-rdns-600)]" aria-hidden="true" />
+                    : <Clipboard className="h-4 w-4 shrink-0 text-[var(--tailwind-colors-rdns-600)]" aria-hidden="true" />}
+            </span>
+            <span className={VALUE_CLASS}>{value}</span>
+        </button>
+    );
+}
 
 export default function FAQ(): JSX.Element {
     const navigate = useNavigate();
@@ -315,24 +359,11 @@ export default function FAQ(): JSX.Element {
                         {serverRows.map(row => (
                             <li key={row.hostname} className="rounded-md border border-[var(--shadcn-ui-app-border)] p-3 text-sm">
                                 <p className="font-medium">{row.city}</p>
-                                <dl className="mt-2 space-y-1.5">
-                                    <div>
-                                        <dt className={TERM_CLASS}>Hostname</dt>
-                                        <dd className={VALUE_CLASS}>{row.hostname}</dd>
-                                    </div>
-                                    {row.ipv4 && (
-                                        <div>
-                                            <dt className={TERM_CLASS}>IPv4</dt>
-                                            <dd className={VALUE_CLASS}>{row.ipv4}</dd>
-                                        </div>
-                                    )}
-                                    {row.ipv6 && (
-                                        <div>
-                                            <dt className={TERM_CLASS}>IPv6</dt>
-                                            <dd className={VALUE_CLASS}>{row.ipv6}</dd>
-                                        </div>
-                                    )}
-                                </dl>
+                                <div className="mt-1 space-y-0.5">
+                                    <CopyRow label="Hostname" value={row.hostname} />
+                                    {row.ipv4 && <CopyRow label="IPv4" value={row.ipv4} />}
+                                    {row.ipv6 && <CopyRow label="IPv6" value={row.ipv6} />}
+                                </div>
                             </li>
                         ))}
                     </ul>

--- a/app/src/pages/legal/FAQ.tsx
+++ b/app/src/pages/legal/FAQ.tsx
@@ -31,9 +31,18 @@ function FAQItem({ question, answer, globalToggleSignal, globalToggleState }: FA
     }, [globalToggleSignal, globalToggleState, lastSignal]);
 
     useEffect(() => {
-        if (contentRef.current) {
-            setHeight(isExpanded ? `${contentRef.current.scrollHeight}px` : '0px');
-        }
+        const el = contentRef.current;
+        if (!el) return;
+        // Measure the inner content, not the wrapper: the wrapper's scrollHeight
+        // never drops below its own explicit height, so it cannot shrink.
+        const inner = (el.firstElementChild as HTMLElement | null) ?? el;
+        setHeight(isExpanded ? `${inner.offsetHeight}px` : '0px');
+        if (!isExpanded || typeof ResizeObserver === 'undefined') return;
+        // The answer reflows when the viewport crosses a breakpoint; keep the
+        // clipped wrapper in step with the content's real height while open.
+        const observer = new ResizeObserver(() => setHeight(`${inner.offsetHeight}px`));
+        observer.observe(inner);
+        return () => observer.disconnect();
     }, [isExpanded]);
 
     const handleToggle = () => {
@@ -104,6 +113,8 @@ const FAQ_LAST_UPDATED = 'September 3, 2026';
 
 const CODE_CLASS = "text-[var(--shadcn-ui-app-foreground)] px-2 py-0.5 rounded text-sm font-mono border border-[var(--shadcn-ui-app-border)]";
 const TABLE_CELL_CLASS = "border border-[var(--shadcn-ui-app-border)] px-3 py-2 text-left align-top";
+const TERM_CLASS = "text-xs uppercase tracking-wide text-[var(--shadcn-ui-app-muted-foreground)]";
+const VALUE_CLASS = "min-w-0 break-all font-mono select-all";
 
 export default function FAQ(): JSX.Element {
     const navigate = useNavigate();
@@ -300,7 +311,32 @@ export default function FAQ(): JSX.Element {
             {serverLocations.length > 0 && (
                 <div className="space-y-2">
                     <p>Currently available locations:</p>
-                    <div className="overflow-x-auto">
+                    <ul className="lg:hidden space-y-2">
+                        {serverRows.map(row => (
+                            <li key={row.hostname} className="rounded-md border border-[var(--shadcn-ui-app-border)] p-3 text-sm">
+                                <p className="font-medium">{row.city}</p>
+                                <dl className="mt-2 space-y-1.5">
+                                    <div>
+                                        <dt className={TERM_CLASS}>Hostname</dt>
+                                        <dd className={VALUE_CLASS}>{row.hostname}</dd>
+                                    </div>
+                                    {row.ipv4 && (
+                                        <div>
+                                            <dt className={TERM_CLASS}>IPv4</dt>
+                                            <dd className={VALUE_CLASS}>{row.ipv4}</dd>
+                                        </div>
+                                    )}
+                                    {row.ipv6 && (
+                                        <div>
+                                            <dt className={TERM_CLASS}>IPv6</dt>
+                                            <dd className={VALUE_CLASS}>{row.ipv6}</dd>
+                                        </div>
+                                    )}
+                                </dl>
+                            </li>
+                        ))}
+                    </ul>
+                    <div className="hidden lg:block overflow-x-auto">
                         <table className="w-full border-collapse text-sm">
                             <thead>
                                 <tr>


### PR DESCRIPTION
- **feat(app): add confirm-new-email step with lockout warning to the change-email dialog**
- **fix(api): normalize account emails to lowercase on write and lookup**
- **fix(api): reject email change to an address already in use before persistence**
- **fix(api): invalidate pending password-reset tokens on email change**
- **chore(app): list PoP IPv4/IPv6 addresses in FAQ troubleshooting entry**
- **fix(app): stack FAQ server locations as cards on narrow screens**
- **chore(app): Add copy buttons for all mobile PoP cards**